### PR TITLE
Feat: support for ACL

### DIFF
--- a/src/components/AclCheck.svelte
+++ b/src/components/AclCheck.svelte
@@ -1,6 +1,6 @@
 <script type="ts">
   import CircularProgress from "@smui/circular-progress";
-  import { onDestroy, onMount } from "svelte";
+  import { onMount } from "svelte";
 
   import Ethereum from "../pages/connect/odoo/Ethereum.svelte";
   import { acl } from "../state/resolutions";
@@ -12,6 +12,7 @@
     timeout = setTimeout(() => {
       displayConnect = true;
     }, 3000);
+    return () => clearTimeout(timeout);
   });
 
   $: {
@@ -19,10 +20,6 @@
       clearTimeout(timeout);
     }
   }
-
-  onDestroy(() => {
-    clearTimeout(timeout);
-  });
 </script>
 
 {#if !$acl.loaded}

--- a/src/components/AclCheck.svelte
+++ b/src/components/AclCheck.svelte
@@ -1,0 +1,34 @@
+<script type="ts">
+  import CircularProgress from "@smui/circular-progress";
+  import { onDestroy, onMount } from "svelte";
+
+  import Ethereum from "../pages/connect/odoo/Ethereum.svelte";
+  import { acl } from "../state/resolutions";
+
+  let timeout = null;
+  let displayConnect = false;
+
+  onMount(() => {
+    timeout = setTimeout(() => {
+      displayConnect = true;
+    }, 3000);
+  });
+
+  $: {
+    if ($acl.loaded) {
+      clearTimeout(timeout);
+    }
+  }
+
+  onDestroy(() => {
+    clearTimeout(timeout);
+  });
+</script>
+
+{#if !$acl.loaded}
+  {#if displayConnect}
+    <Ethereum />
+  {:else}
+    <CircularProgress style="height: 32px; width: 32px;" indeterminate />
+  {/if}
+{/if}

--- a/src/components/CurrentTimestamp.svelte
+++ b/src/components/CurrentTimestamp.svelte
@@ -1,5 +1,5 @@
 <script type="ts">
-  import { onDestroy, onMount } from "svelte";
+  import { onMount } from "svelte";
 
   import { currentTimestamp } from "../state/resolutions";
 
@@ -8,11 +8,9 @@
 
   onMount(() => {
     interval = setInterval(() => {
-      $currentTimestamp = +new Date();
+      $currentTimestamp = Date.now();
     }, intervalMs);
-  });
 
-  onDestroy(() => {
-    clearInterval(interval);
+    return () => clearInterval(interval);
   });
 </script>

--- a/src/components/ResolutionForm.svelte
+++ b/src/components/ResolutionForm.svelte
@@ -18,6 +18,7 @@
   import type { ResolutionTypeEntity } from "../types";
   import { graphQLClient } from "../net/graphQl";
   import { getResolutionTypesQuery } from "../graphql/get-resolution-types.query";
+  import { acl } from "../state/resolutions";
 
   function init(el: HTMLElement) {
     el.querySelector("input").focus();
@@ -144,7 +145,7 @@
             {#if selectedType?.canBeNegative}
               <FormField>
                 <Checkbox bind:checked={$currentResolution.isNegative} />
-                <span slot="label"> Negative resolution. </span>
+                <span slot="label">Negative resolution.</span>
               </FormField>
             {/if}
           </Cell>
@@ -177,22 +178,25 @@
               >
             {/if}
           </Wrapper>
-          <Wrapper>
-            <span tabindex="0">
-              <Button
-                variant="raised"
-                disabled={disabled || !disabledUpdate}
-                on:click={handleApprove}
-              >
-                <Label>Approve</Label>
-              </Button>
-            </span>
-            {#if disabled || !disabledUpdate}
-              <Tooltip unbounded
-                >It looks you need to update the resolution before approving it</Tooltip
-              >
-            {/if}
-          </Wrapper>
+          {#if $acl.canApprove}
+            <Wrapper>
+              <span tabindex="0">
+                <Button
+                  variant="raised"
+                  disabled={disabled || !disabledUpdate}
+                  on:click={handleApprove}
+                >
+                  <Label>Approve</Label>
+                </Button>
+              </span>
+              {#if disabled || !disabledUpdate}
+                <Tooltip unbounded
+                  >It looks you need to update the resolution before approving
+                  it</Tooltip
+                >
+              {/if}
+            </Wrapper>
+          {/if}
         </Group>
       {:else}
         <Button variant="raised" {disabled} on:click={handleSave}>

--- a/src/components/ResolutionForm.svelte
+++ b/src/components/ResolutionForm.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, onMount } from "svelte";
+  import { onMount } from "svelte";
   import Select, { Option } from "@smui/select";
   import Button, { Label, Group } from "@smui/button";
   import CircularProgress from "@smui/circular-progress";
@@ -43,6 +43,8 @@
       resolutionTypes: ResolutionTypeEntity[];
     } = await graphQLClient.request(getResolutionTypesQuery);
     resolutionTypes = resolutionsTypesData;
+
+    return resetForm;
   });
 
   $: {
@@ -60,8 +62,6 @@
       );
     }
   }
-
-  onDestroy(resetForm);
 </script>
 
 <section class="section">

--- a/src/components/ResolutionView.svelte
+++ b/src/components/ResolutionView.svelte
@@ -6,6 +6,7 @@
   import VotingWidget from "./VotingWidget.svelte";
   import type { ResolutionEntityEnhanced } from "../types";
   import ResolutionDetails from "./ResolutionDetails.svelte";
+  import { acl } from "../state/resolutions";
 
   export let resolution: ResolutionEntityEnhanced;
   let isPrint: boolean;
@@ -26,7 +27,7 @@
   {#if resolution.isNegative}
     <small><em>Negative resolution</em></small>
   {/if}
-  {#if !isPrint && resolution.state === RESOLUTION_STATES.VOTING}
+  {#if !isPrint && resolution.state === RESOLUTION_STATES.VOTING && $acl.canVote(resolution.voters)}
     <div class="voting">
       <VotingWidget resolutionId={resolution.id} />
     </div>

--- a/src/graphql/get-resolution-manager.query.ts
+++ b/src/graphql/get-resolution-manager.query.ts
@@ -1,0 +1,12 @@
+import { gql } from "graphql-request";
+import { resolutionManagerFragment } from "./resolution-manager.fragment";
+
+export const getResolutionManagerQuery = gql`
+  query GetResolutionManager {
+    resolutionManager(id: "0") {
+      ...resolutionManagerFragment
+    }
+  }
+
+  ${resolutionManagerFragment}
+`;

--- a/src/graphql/get-resolution.query.ts
+++ b/src/graphql/get-resolution.query.ts
@@ -1,4 +1,5 @@
 import { gql } from "graphql-request";
+import { resolutionManagerFragment } from "./resolution-manager.fragment";
 import { resolutionFragment } from "./resolution.fragment";
 
 export const getResolutionQuery = gql`
@@ -6,7 +7,12 @@ export const getResolutionQuery = gql`
     resolution(id: $id) {
       ...resolutionFragment
     }
+
+    resolutionManager(id: "0") {
+      ...resolutionManagerFragment
+    }
   }
 
   ${resolutionFragment}
+  ${resolutionManagerFragment}
 `;

--- a/src/graphql/get-resolution.query.ts
+++ b/src/graphql/get-resolution.query.ts
@@ -7,12 +7,7 @@ export const getResolutionQuery = gql`
     resolution(id: $id) {
       ...resolutionFragment
     }
-
-    resolutionManager(id: "0") {
-      ...resolutionManagerFragment
-    }
   }
 
   ${resolutionFragment}
-  ${resolutionManagerFragment}
 `;

--- a/src/graphql/get-resolutions.query.ts
+++ b/src/graphql/get-resolutions.query.ts
@@ -1,5 +1,4 @@
 import { gql } from "graphql-request";
-import { resolutionManagerFragment } from "./resolution-manager.fragment";
 import { resolutionFragment } from "./resolution.fragment";
 
 export const getResolutionsQuery = gql`
@@ -7,12 +6,7 @@ export const getResolutionsQuery = gql`
     resolutions(orderBy: createTimestamp, orderDirection: desc) {
       ...resolutionFragment
     }
-
-    resolutionManager(id: "0") {
-      ...resolutionManagerFragment
-    }
   }
 
   ${resolutionFragment}
-  ${resolutionManagerFragment}
 `;

--- a/src/graphql/get-resolutions.query.ts
+++ b/src/graphql/get-resolutions.query.ts
@@ -1,4 +1,5 @@
 import { gql } from "graphql-request";
+import { resolutionManagerFragment } from "./resolution-manager.fragment";
 import { resolutionFragment } from "./resolution.fragment";
 
 export const getResolutionsQuery = gql`
@@ -6,7 +7,12 @@ export const getResolutionsQuery = gql`
     resolutions(orderBy: createTimestamp, orderDirection: desc) {
       ...resolutionFragment
     }
+
+    resolutionManager(id: "0") {
+      ...resolutionManagerFragment
+    }
   }
 
   ${resolutionFragment}
+  ${resolutionManagerFragment}
 `;

--- a/src/graphql/resolution-manager.fragment.ts
+++ b/src/graphql/resolution-manager.fragment.ts
@@ -1,0 +1,11 @@
+import { gql } from "graphql-request";
+
+export const resolutionManagerFragment = gql`
+  fragment resolutionManagerFragment on ResolutionManager {
+    id
+    foundersAddresses
+    contributorsAddresses
+    investorsAddresses
+    shareholdersAddresses
+  }
+`;

--- a/src/graphql/resolution.fragment.ts
+++ b/src/graphql/resolution.fragment.ts
@@ -17,6 +17,10 @@ export const resolutionFragment = gql`
     createBy
     updateBy
     approveBy
+    voters {
+      votingPower
+      address
+    }
   }
 
   ${resolutionTypeFragment}

--- a/src/graphql/resolution.fragment.ts
+++ b/src/graphql/resolution.fragment.ts
@@ -11,9 +11,12 @@ export const resolutionFragment = gql`
       ...resolutionTypeFragment
     }
     yesVotesTotal
-    approveTimestamp
     createTimestamp
     updateTimestamp
+    approveTimestamp
+    createBy
+    updateBy
+    approveBy
   }
 
   ${resolutionTypeFragment}

--- a/src/pages/resolutions/Edit.svelte
+++ b/src/pages/resolutions/Edit.svelte
@@ -35,6 +35,9 @@
   let open = false;
   let loaded = false;
 
+  // TODO, should we spin a timeout here? if i.e. after 5 seconds acl is still not loaded, probably
+  // we can display a message to the user with "You should re-connect your wallet"? or we shouldn't care?
+
   onMount(async () => {
     const {
       resolution,
@@ -127,7 +130,7 @@
   </Actions>
 </Dialog>
 
-{#if !loaded}
+{#if !loaded || !$acl.loaded}
   <CircularProgress style="height: 32px; width: 32px;" indeterminate />
 {:else}
   <ResolutionForm

--- a/src/pages/resolutions/Edit.svelte
+++ b/src/pages/resolutions/Edit.svelte
@@ -2,7 +2,7 @@
   import { replace } from "svelte-spa-router";
   import isEqual from "lodash.isequal";
   import Dialog, { Title, Content, Actions } from "@smui/dialog";
-  import { onDestroy, onMount } from "svelte";
+  import { onMount } from "svelte";
   import Button, { Label } from "@smui/button";
 
   import ResolutionForm from "../../components/ResolutionForm.svelte";
@@ -52,6 +52,8 @@
       isNegative: resolutionData.isNegative,
       typeId: resolutionData.resolutionType.id,
     };
+
+    return resetForm;
   });
 
   $: {
@@ -71,7 +73,7 @@
 
     const shouldRedirectToView =
       (resolutionTypeInfo &&
-        getResolutionState(resolutionData, +new Date(), resolutionTypeInfo) !==
+        getResolutionState(resolutionData, Date.now(), resolutionTypeInfo) !==
           RESOLUTION_STATES.PRE_DRAFT) ||
       ($acl.loaded && !$acl.canUpdate);
 
@@ -104,8 +106,6 @@
     open = false;
     handleApprove(params.resolutionId, { $signer, $resolutionContract });
   }
-
-  onDestroy(resetForm);
 </script>
 
 <Dialog

--- a/src/pages/resolutions/Edit.svelte
+++ b/src/pages/resolutions/Edit.svelte
@@ -127,9 +127,9 @@
   </Actions>
 </Dialog>
 
-{#if !loaded || !$acl.loaded}
-  <AclCheck />
-{:else}
+<AclCheck />
+
+{#if loaded}
   <ResolutionForm
     handleSave={handleUpdateResolution}
     editMode

--- a/src/pages/resolutions/Edit.svelte
+++ b/src/pages/resolutions/Edit.svelte
@@ -129,7 +129,7 @@
 
 <AclCheck />
 
-{#if loaded}
+{#if loaded && $acl.loaded}
   <ResolutionForm
     handleSave={handleUpdateResolution}
     editMode

--- a/src/pages/resolutions/Edit.svelte
+++ b/src/pages/resolutions/Edit.svelte
@@ -4,7 +4,6 @@
   import Dialog, { Title, Content, Actions } from "@smui/dialog";
   import { onDestroy, onMount } from "svelte";
   import Button, { Label } from "@smui/button";
-  import CircularProgress from "@smui/circular-progress";
 
   import ResolutionForm from "../../components/ResolutionForm.svelte";
   import { resolutionContract, signer } from "../../state/eth";
@@ -21,6 +20,7 @@
   } from "../../helpers/resolutions";
   import { currentResolution, resetForm } from "../../state/resolutions/form";
   import { acl } from "../../state/resolutions";
+  import AclCheck from "../../components/AclCheck.svelte";
 
   type Params = {
     resolutionId: string;
@@ -34,9 +34,6 @@
   let disabledUpdate = true;
   let open = false;
   let loaded = false;
-
-  // TODO, should we spin a timeout here? if i.e. after 5 seconds acl is still not loaded, probably
-  // we can display a message to the user with "You should re-connect your wallet"? or we shouldn't care?
 
   onMount(async () => {
     const {
@@ -131,7 +128,7 @@
 </Dialog>
 
 {#if !loaded || !$acl.loaded}
-  <CircularProgress style="height: 32px; width: 32px;" indeterminate />
+  <AclCheck />
 {:else}
   <ResolutionForm
     handleSave={handleUpdateResolution}

--- a/src/pages/resolutions/Edit.svelte
+++ b/src/pages/resolutions/Edit.svelte
@@ -20,6 +20,7 @@
     RESOLUTION_STATES,
   } from "../../helpers/resolutions";
   import { currentResolution, resetForm } from "../../state/resolutions/form";
+  import { acl } from "../../state/resolutions";
 
   type Params = {
     resolutionId: string;
@@ -68,11 +69,13 @@
       ? getResolutionTypeInfo(resolutionData)
       : null;
 
-    if (
-      resolutionTypeInfo &&
-      getResolutionState(resolutionData, +new Date(), resolutionTypeInfo) !==
-        RESOLUTION_STATES.PRE_DRAFT
-    ) {
+    const shouldRedirectToView =
+      (resolutionTypeInfo &&
+        getResolutionState(resolutionData, +new Date(), resolutionTypeInfo) !==
+          RESOLUTION_STATES.PRE_DRAFT) ||
+      ($acl.loaded && !$acl.canUpdate);
+
+    if (shouldRedirectToView) {
       replace(`/resolutions/${params.resolutionId}`);
     }
 

--- a/src/pages/resolutions/Index.svelte
+++ b/src/pages/resolutions/Index.svelte
@@ -9,27 +9,36 @@
   import { graphQLClient } from "../../net/graphQl";
   import { getResolutionsQuery } from "../../graphql/get-resolutions.query";
 
-  import type { ResolutionEntityEnhanced } from "../../types";
+  import type {
+    ResolutionEntityEnhanced,
+    ResolutionManagerEntity,
+    ResolutionTypeEntity,
+  } from "../../types";
   import { getEnhancedResolutions } from "../../helpers/resolutions";
   import { currentTimestamp } from "../../state/resolutions";
   import CurrentTimestamp from "../../components/CurrentTimestamp.svelte";
   import ResolutionDetails from "../../components/ResolutionDetails.svelte";
 
   let resolutions: ResolutionEntityEnhanced[];
+  let resolutionManager: ResolutionManagerEntity;
   let ready = false;
   let empty = false;
 
   onMount(async () => {
     const {
       resolutions: resolutionsData,
+      resolutionManager: resolutionManagerData,
     }: {
       resolutions: ResolutionEntityEnhanced[];
+      resolutionManager: ResolutionManagerEntity;
     } = await graphQLClient.request(getResolutionsQuery);
     resolutions = resolutionsData;
+    resolutionManager = resolutionManagerData;
   });
 
   $: {
-    if (resolutions) {
+    if (resolutions && resolutionManager) {
+      console.log("resolutionManager: ", resolutionManager);
       resolutions = getEnhancedResolutions(resolutions, $currentTimestamp);
       ready = true;
       empty = resolutions.length === 0;

--- a/src/pages/resolutions/New.svelte
+++ b/src/pages/resolutions/New.svelte
@@ -30,8 +30,8 @@
   }
 </script>
 
-{#if !$acl.loaded}
-  <AclCheck />
-{:else}
+<AclCheck />
+
+{#if $acl.loaded}
   <ResolutionForm handleSave={handleContractPreDraft} />
 {/if}

--- a/src/pages/resolutions/New.svelte
+++ b/src/pages/resolutions/New.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
+  import { notifier } from "@beyonk/svelte-notifications";
+  import CircularProgress from "@smui/circular-progress";
+  import { replace } from "svelte-spa-router";
+  import { onMount } from "svelte";
+
   import { title } from "../../state/runtime";
   import ResolutionForm from "../../components/ResolutionForm.svelte";
   import { resolutionContract, signer } from "../../state/eth";
   import { currentResolution, resetForm } from "../../state/resolutions/form";
-  import { onMount } from "svelte";
   import { handleCreate } from "../../handlers/resolutions/create";
   import { acl } from "../../state/resolutions";
-  import { notifier } from "@beyonk/svelte-notifications";
-  import { replace } from "svelte-spa-router";
 
   title.set("Resolutions");
 
@@ -16,6 +18,9 @@
   }
 
   onMount(resetForm);
+
+  // TODO, should we spin a timeout here? if i.e. after 5 seconds acl is still not loaded, probably
+  // we can display a message to the user with "You should re-connect your wallet"? or we shouldn't care?
 
   $: {
     if ($acl.loaded && !$acl.canCreate) {
@@ -28,4 +33,8 @@
   }
 </script>
 
-<ResolutionForm handleSave={handleContractPreDraft} />
+{#if !$acl.loaded}
+  <CircularProgress style="height: 32px; width: 32px;" indeterminate />
+{:else}
+  <ResolutionForm handleSave={handleContractPreDraft} />
+{/if}

--- a/src/pages/resolutions/New.svelte
+++ b/src/pages/resolutions/New.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { notifier } from "@beyonk/svelte-notifications";
-  import CircularProgress from "@smui/circular-progress";
   import { replace } from "svelte-spa-router";
   import { onMount } from "svelte";
 
@@ -10,6 +9,7 @@
   import { currentResolution, resetForm } from "../../state/resolutions/form";
   import { handleCreate } from "../../handlers/resolutions/create";
   import { acl } from "../../state/resolutions";
+  import AclCheck from "../../components/AclCheck.svelte";
 
   title.set("Resolutions");
 
@@ -18,9 +18,6 @@
   }
 
   onMount(resetForm);
-
-  // TODO, should we spin a timeout here? if i.e. after 5 seconds acl is still not loaded, probably
-  // we can display a message to the user with "You should re-connect your wallet"? or we shouldn't care?
 
   $: {
     if ($acl.loaded && !$acl.canCreate) {
@@ -34,7 +31,7 @@
 </script>
 
 {#if !$acl.loaded}
-  <CircularProgress style="height: 32px; width: 32px;" indeterminate />
+  <AclCheck />
 {:else}
   <ResolutionForm handleSave={handleContractPreDraft} />
 {/if}

--- a/src/pages/resolutions/New.svelte
+++ b/src/pages/resolutions/New.svelte
@@ -5,6 +5,9 @@
   import { currentResolution, resetForm } from "../../state/resolutions/form";
   import { onMount } from "svelte";
   import { handleCreate } from "../../handlers/resolutions/create";
+  import { acl } from "../../state/resolutions";
+  import { notifier } from "@beyonk/svelte-notifications";
+  import { replace } from "svelte-spa-router";
 
   title.set("Resolutions");
 
@@ -13,6 +16,16 @@
   }
 
   onMount(resetForm);
+
+  $: {
+    if ($acl.loaded && !$acl.canCreate) {
+      notifier.danger(
+        "It looks you cannot create resolutions. Your role is not Contributor",
+        5000
+      );
+      replace(`/resolutions`);
+    }
+  }
 </script>
 
 <ResolutionForm handleSave={handleContractPreDraft} />

--- a/src/pages/resolutions/View.svelte
+++ b/src/pages/resolutions/View.svelte
@@ -7,7 +7,7 @@
   import { graphQLClient } from "../../net/graphQl";
   import type { ResolutionEntity, ResolutionEntityEnhanced } from "../../types";
   import { getEnhancedResolutionMapper } from "../../helpers/resolutions";
-  import { currentTimestamp } from "../../state/resolutions";
+  import { acl, currentTimestamp } from "../../state/resolutions";
   import CurrentTimestamp from "../../components/CurrentTimestamp.svelte";
 
   type Params = {
@@ -33,14 +33,16 @@
   });
 
   $: {
-    if (resolutionData) {
-      resolutionDataEnhanced =
-        getEnhancedResolutionMapper($currentTimestamp)(resolutionData);
+    if (resolutionData && $acl) {
+      resolutionDataEnhanced = getEnhancedResolutionMapper(
+        $currentTimestamp,
+        $acl
+      )(resolutionData);
     }
   }
 </script>
 
-{#if !resolutionData}
+{#if !resolutionDataEnhanced}
   <CircularProgress style="height: 32px; width: 32px;" indeterminate />
 {:else}
   <CurrentTimestamp />

--- a/src/state/resolutions/index.ts
+++ b/src/state/resolutions/index.ts
@@ -8,7 +8,7 @@ import type {
 import { graphQLClient } from "../../net/graphQl";
 import { getResolutionManagerQuery } from "../../graphql/get-resolution-manager.query";
 
-export const currentTimestamp = writable(+new Date());
+export const currentTimestamp = writable(Date.now());
 
 export const acl: Readable<ResolutionsAcl> = derived(signer, ($signer, set) => {
   (async () => {

--- a/src/state/resolutions/index.ts
+++ b/src/state/resolutions/index.ts
@@ -10,34 +10,32 @@ import { getResolutionManagerQuery } from "../../graphql/get-resolution-manager.
 
 export const currentTimestamp = writable(+new Date());
 
-export const acl: Readable<ResolutionsAcl> = derived(
-  signer,
-  ($signer, set) => {
-    (async () => {
-      if ($signer) {
-        const {
-          resolutionManager,
-        }: { resolutionManager: ResolutionManagerEntity } =
-          await graphQLClient.request(getResolutionManagerQuery);
-        const address = (await $signer.getAddress()).toLowerCase();
-        set({
-          canCreate: resolutionManager.contributorsAddresses.includes(address),
-          canUpdate: resolutionManager.foundersAddresses.includes(address),
-          canApprove: resolutionManager.foundersAddresses.includes(address),
-          canVote: (resolutionVoters: ResolutionVoter[]) =>
-            resolutionVoters
-              .map((voter) => voter.address.toLowerCase())
-              .includes(address),
-          loaded: true,
-        });
-      }
-    })();
-  },
-  {
-    canCreate: Boolean(false),
-    canUpdate: Boolean(false),
-    canApprove: Boolean(false),
-    canVote: (_: ResolutionVoter[]) => Boolean(false),
-    loaded: Boolean(false),
-  }
-);
+export const acl: Readable<ResolutionsAcl> = derived(signer, ($signer, set) => {
+  (async () => {
+    if ($signer) {
+      const {
+        resolutionManager,
+      }: { resolutionManager: ResolutionManagerEntity } =
+        await graphQLClient.request(getResolutionManagerQuery);
+      const address = (await $signer.getAddress()).toLowerCase();
+      set({
+        canCreate: resolutionManager.contributorsAddresses.includes(address),
+        canUpdate: resolutionManager.foundersAddresses.includes(address),
+        canApprove: resolutionManager.foundersAddresses.includes(address),
+        canVote: (resolutionVoters: ResolutionVoter[]) =>
+          resolutionVoters
+            .map((voter) => voter.address.toLowerCase())
+            .includes(address),
+        loaded: true,
+      });
+    } else {
+      set({
+        canCreate: Boolean(false),
+        canUpdate: Boolean(false),
+        canApprove: Boolean(false),
+        canVote: (_: ResolutionVoter[]) => Boolean(false),
+        loaded: Boolean(false),
+      });
+    }
+  })();
+});

--- a/src/state/resolutions/index.ts
+++ b/src/state/resolutions/index.ts
@@ -1,3 +1,43 @@
-import { writable } from "svelte/store";
+import { writable, derived, Readable } from "svelte/store";
+import { signer } from "../eth";
+import type {
+  ResolutionManagerEntity,
+  ResolutionsAcl,
+  ResolutionVoter,
+} from "../../types";
+import { graphQLClient } from "../../net/graphQl";
+import { getResolutionManagerQuery } from "../../graphql/get-resolution-manager.query";
 
 export const currentTimestamp = writable(+new Date());
+
+export const acl: Readable<ResolutionsAcl> = derived(
+  signer,
+  ($signer, set) => {
+    (async () => {
+      if ($signer) {
+        const {
+          resolutionManager,
+        }: { resolutionManager: ResolutionManagerEntity } =
+          await graphQLClient.request(getResolutionManagerQuery);
+        const address = (await $signer.getAddress()).toLowerCase();
+        set({
+          canCreate: resolutionManager.contributorsAddresses.includes(address),
+          canUpdate: resolutionManager.foundersAddresses.includes(address),
+          canApprove: resolutionManager.foundersAddresses.includes(address),
+          canVote: (resolutionVoters: ResolutionVoter[]) =>
+            resolutionVoters
+              .map((voter) => voter.address.toLowerCase())
+              .includes(address),
+          loaded: true,
+        });
+      }
+    })();
+  },
+  {
+    canCreate: Boolean(false),
+    canUpdate: Boolean(false),
+    canApprove: Boolean(false),
+    canVote: (_: ResolutionVoter[]) => Boolean(false),
+    loaded: Boolean(false),
+  }
+);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,17 @@
+export type ResolutionVoter = {
+  id: string;
+  votingPower: number;
+  address: string;
+};
+
+export type ResolutionsAcl = {
+  canCreate: boolean;
+  canUpdate: boolean;
+  canApprove: boolean;
+  canVote: (voters: ResolutionVoter[]) => boolean;
+  loaded: boolean;
+};
+
 export type ResolutionTypeEntity = {
   id: string;
   name: string;
@@ -9,11 +23,11 @@ export type ResolutionTypeEntity = {
 
 export type ResolutionManagerEntity = {
   id: string;
-  name: string;
-  quorum: string;
-  noticePeriod: string;
-  votingPeriod: string;
-  canBeNegative: boolean;
+  contributorsAddresses: string[];
+  foundersAddresses: string[];
+  shareholdersAddresses: string[];
+  investorsAddresses: string[];
+  resolutionTypes: ResolutionTypeEntity[];
 };
 
 export type ResolutionEntity = {
@@ -29,6 +43,7 @@ export type ResolutionEntity = {
   createBy: string;
   updateBy: string;
   approveBy: string;
+  voters: ResolutionVoter[];
 };
 
 export type ResolutionAction = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,15 @@ export type ResolutionTypeEntity = {
   canBeNegative: boolean;
 };
 
+export type ResolutionManagerEntity = {
+  id: string;
+  name: string;
+  quorum: string;
+  noticePeriod: string;
+  votingPeriod: string;
+  canBeNegative: boolean;
+};
+
 export type ResolutionEntity = {
   id: string;
   title: string;
@@ -14,9 +23,12 @@ export type ResolutionEntity = {
   isNegative: boolean;
   resolutionType: ResolutionTypeEntity;
   yesVotesTotal: string;
-  approveTimestamp: string;
   createTimestamp: string;
   updateTimestamp: string;
+  approveTimestamp: string;
+  createBy: string;
+  updateBy: string;
+  approveBy: string;
 };
 
 export type ResolutionAction = {

--- a/test/unit/helpers/resolution.ts
+++ b/test/unit/helpers/resolution.ts
@@ -5,6 +5,7 @@ import {
   createEnhancedResolutionEntity,
 } from "../mocks/resolutionEntityFactory";
 import { getEnhancedResolutionMapper } from "../../../src/helpers/resolutions";
+import { createResolutionsAcl } from "../mocks/resolutionsAclFactory";
 import {
   RESOLUTION_STATES,
   getResolutionState,
@@ -14,7 +15,6 @@ import {
   getRelativeDateFromUnixTimestamp,
   getResolutionTypeInfo,
 } from "../../../src/helpers/resolutions";
-import type { ResolutionManager } from "../../../contracts/typechain/ResolutionManager";
 
 const FEB_25_2022_UNIX_TS = "1645808255"; // Fri Feb 25 2022 17:57:35
 const FEB_26_2022_TS = 1645915897665; // Sat Feb 26 2022 23:51:37 GMT+0100 (Central European Standard Time)
@@ -122,15 +122,58 @@ describe("Resolution helpers", () => {
   describe("getEnhancedResolutionMapper", () => {
     it("should correctly enhance a resolution entity coming from subgraph", () => {
       const resolutionEntity = createResolutionEntity();
+      const acl = createResolutionsAcl();
 
       const mapper = getEnhancedResolutionMapper(
-        Number(FEB_25_2022_UNIX_TS) * 1000
+        Number(FEB_25_2022_UNIX_TS) * 1000,
+        acl
       );
       const enhancedResolution = mapper(resolutionEntity);
 
       const exptectedOutput = createEnhancedResolutionEntity();
 
       expect(enhancedResolution).to.deep.equal(exptectedOutput);
+    });
+
+    describe("ACL", () => {
+      it("should correctly map a resolution for a FOUNDER", () => {
+        const resolutionEntity = createResolutionEntity();
+        const acl = createResolutionsAcl();
+
+        const mapper = getEnhancedResolutionMapper(
+          Number(FEB_25_2022_UNIX_TS) * 1000,
+          acl
+        );
+        const enhancedResolution = mapper(resolutionEntity);
+
+        const exptectedOutput = createEnhancedResolutionEntity();
+
+        expect(enhancedResolution).to.deep.equal(exptectedOutput);
+      });
+
+      it("should correctly map a resolution for a CONTRIBUTOR", () => {
+        const resolutionEntity = createResolutionEntity();
+        const acl = createResolutionsAcl({
+          canApprove: false,
+          canUpdate: false,
+        });
+
+        const mapper = getEnhancedResolutionMapper(
+          Number(FEB_25_2022_UNIX_TS) * 1000,
+          acl
+        );
+        const enhancedResolution = mapper(resolutionEntity);
+
+        const exptectedOutput = createEnhancedResolutionEntity({
+          href: "#/resolutions/42",
+          action: {
+            label: "View",
+            disabled: false,
+          },
+        });
+
+        expect(enhancedResolution).to.deep.equal(exptectedOutput);
+      });
     });
   });
 });

--- a/test/unit/helpers/resolution.ts
+++ b/test/unit/helpers/resolution.ts
@@ -69,7 +69,7 @@ describe("Resolution helpers", () => {
       const resolutionTypeInfo = getResolutionTypeInfo(resolutionEntity);
       const resolutionState = getResolutionState(
         resolutionEntity,
-        +new Date(),
+        Date.now(),
         resolutionTypeInfo
       );
 

--- a/test/unit/mocks/resolutionEntityFactory.ts
+++ b/test/unit/mocks/resolutionEntityFactory.ts
@@ -20,6 +20,10 @@ const defaultEntity: ResolutionEntity = {
   approveTimestamp: "0",
   createTimestamp: "1645808255",
   updateTimestamp: "0",
+  voters: [],
+  createBy: "42",
+  updateBy: "42",
+  approveBy: "42",
 };
 
 const enhancedEntity: ResolutionEntityEnhanced = {
@@ -44,6 +48,10 @@ const enhancedEntity: ResolutionEntityEnhanced = {
     votingEnds: null,
     votingEndsAt: null,
   },
+  voters: [],
+  createBy: "42",
+  updateBy: "42",
+  approveBy: "42",
 };
 
 export const createResolutionEntity = (

--- a/test/unit/mocks/resolutionEntityFactory.ts
+++ b/test/unit/mocks/resolutionEntityFactory.ts
@@ -41,7 +41,7 @@ const enhancedEntity: ResolutionEntityEnhanced = {
   updatedAt: null,
   approvedAt: null,
   href: "#/resolutions/42/edit",
-  action: { label: "Edit", disabled: false },
+  action: { label: "Edit or Approve", disabled: false },
   resolutionTypeInfo: {
     noticePeriodEnds: null,
     noticePeriodEndsAt: null,

--- a/test/unit/mocks/resolutionEntityFactory.ts
+++ b/test/unit/mocks/resolutionEntityFactory.ts
@@ -6,16 +6,16 @@ import type {
 
 import resolutionTypes from "./resolutionTypes.json";
 
-const defaultResolutionType: ResolutionTypeEntity = resolutionTypes.find(
-  (res) => res.id === "4"
-);
+const defaultResolutionType: (id: string) => ResolutionTypeEntity = (
+  id: string
+) => resolutionTypes.find((res) => res.id === id);
 
 const defaultEntity: ResolutionEntity = {
   id: "42",
   title: "A new hope",
   content: "Another resolution",
   isNegative: false,
-  resolutionType: defaultResolutionType,
+  resolutionType: defaultResolutionType("4"),
   yesVotesTotal: "0",
   approveTimestamp: "0",
   createTimestamp: "1645808255",
@@ -27,7 +27,7 @@ const enhancedEntity: ResolutionEntityEnhanced = {
   title: "A new hope",
   content: "Another resolution",
   isNegative: false,
-  resolutionType: defaultResolutionType,
+  resolutionType: defaultResolutionType("4"),
   yesVotesTotal: "0",
   approveTimestamp: "0",
   createTimestamp: "1645808255",

--- a/test/unit/mocks/resolutionsAclFactory.ts
+++ b/test/unit/mocks/resolutionsAclFactory.ts
@@ -1,0 +1,12 @@
+import type { ResolutionsAcl } from "../../../src/types";
+
+export const createResolutionsAcl = (
+  overrides: Partial<ResolutionsAcl> = {}
+): ResolutionsAcl => ({
+  canCreate: true,
+  canUpdate: true,
+  canApprove: true,
+  canVote: () => true,
+  loaded: true,
+  ...overrides,
+});


### PR DESCRIPTION
Added support for ACL, getting the data from subgraph (via graphql).

On resolutions list:
 - resolutions list can be viewed by everyone (even if the wallet is not connected. @vrde to confirm)
 - just contributors/founders can view the "Create new resolution" button
 - just founders can view the "edit or approve" button (for pre-drafts)

On resolution create form:
  - if hacky hacker gets into the `/resolutions/new` page we check if they are contributors, otherwise:
    - if they're wallet-connected we redirect to the list page
    - if they're not wallet-connected we just keep a spinner spinnin'
  - if a user is a contributor (or founder, ofc) they can fill in the form and create it

On resolution edit form:
  - if hacky hacker gets into the `/resolutions/:id/edit` page we check if they are founders, otherwise:
    - if they're wallet-connected we redirect to the `/resolutions/:id` (view) page
    - if they're not wallet-connected we just keep a spinner spinnin'

On resolution view:
  - if users are not on the voters list (after checking if we're in the voting state, ofc), we just don't display the voting widget. By default, if ACL is not loaded, no one can vote